### PR TITLE
Fix memory management for static block variables in UIAlertView+MKBlockAdditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.mode1
+*.mode1v3
+*.mode2v3
+*.perspective
+*.perspectivev3
+*.pbxuser
+xcuserdata/

--- a/MKAdditions/UIActionSheet+MKBlockAdditions.m
+++ b/MKAdditions/UIActionSheet+MKBlockAdditions.m
@@ -46,7 +46,7 @@ static UIViewController *_presentVC;
     _dismissBlock  = [dismissed copy];
 
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:title 
-                                                             delegate:[self class] 
+                                                             delegate:(id <UIActionSheetDelegate>)[self class] 
                                                     cancelButtonTitle:nil
                                                destructiveButtonTitle:destructiveButtonTitle 
                                                     otherButtonTitles:nil];
@@ -91,7 +91,7 @@ static UIViewController *_presentVC;
     int cancelButtonIndex = -1;
 
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:title 
-                                                             delegate:[self class] 
+                                                             delegate:(id <UIActionSheetDelegate>)[self class] 
 													cancelButtonTitle:nil
 											   destructiveButtonTitle:nil
 													otherButtonTitles:nil];
@@ -168,7 +168,7 @@ static UIViewController *_presentVC;
             
             
             UIImagePickerController *picker = [[UIImagePickerController alloc] init];
-            picker.delegate = [self class];
+            picker.delegate = (id <UINavigationControllerDelegate, UIImagePickerControllerDelegate>)[self class];
             picker.allowsEditing = YES;
             
             if(buttonIndex == 1) 

--- a/MKAdditions/UIAlertView+MKBlockAdditions.m
+++ b/MKAdditions/UIAlertView+MKBlockAdditions.m
@@ -70,6 +70,11 @@ static CancelBlock _cancelBlock;
     {
         _dismissBlock(buttonIndex - 1); // cancel button is button 0
     }
+    
+    [_cancelBlock release];
+    _cancelBlock = nil;
+    [_dismissBlock release];
+    _dismissBlock = nil;
 }
 
 @end

--- a/UIKitCategoryAdditions.xcodeproj/project.pbxproj
+++ b/UIKitCategoryAdditions.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 /* Begin PBXProject section */
 		AB5E75411336DD790016813D /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0430;
+			};
 			buildConfigurationList = AB5E75441336DD790016813D /* Build configuration list for PBXProject "UIKitCategoryAdditions" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -257,7 +260,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UIKitCategoryAdditions/UIKitCategoryAdditions-Prefix.pch";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "UIKitCategoryAdditions/UIKitCategoryAdditions-Info.plist";
 				PRODUCT_NAME = UIKitCategoryAdditions;
 				WRAPPER_EXTENSION = app;
@@ -271,7 +274,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "UIKitCategoryAdditions/UIKitCategoryAdditions-Prefix.pch";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "UIKitCategoryAdditions/UIKitCategoryAdditions-Info.plist";
 				PRODUCT_NAME = UIKitCategoryAdditions;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
If objects referenced in the blocks are deallocated, in the next invocation of alertViewWithTitle:message:cancelButtonTitle:otherButtonTitles:onDismiss:onCancel: block arguments still reference to deallocated instances causing crash.
Fix the case if more than one UIAlertView is shown using block-based category method.
Add thread safety.
