### PR TITLE
Avoid using static blocks for UIAlertView

### DIFF
--- a/MKAdditions/UIAlertView+MKBlockAdditions.h
+++ b/MKAdditions/UIAlertView+MKBlockAdditions.h
@@ -24,4 +24,7 @@
                           onDismiss:(DismissBlock) dismissed                   
                            onCancel:(CancelBlock) cancelled;
 
+@property (nonatomic, copy) DismissBlock dismissBlock;
+@property (nonatomic, copy) CancelBlock cancelBlock;
+
 @end

--- a/MKAdditions/UIAlertView+MKBlockAdditions.m
+++ b/MKAdditions/UIAlertView+MKBlockAdditions.m
@@ -7,11 +7,36 @@
 //
 
 #import "UIAlertView+MKBlockAdditions.h"
+#import <objc/runtime.h>
 
-static DismissBlock _dismissBlock;
-static CancelBlock _cancelBlock;
+static char DISMISS_IDENTIFER;
+static char CANCEL_IDENTIFER;
 
 @implementation UIAlertView (Block)
+
+@dynamic cancelBlock;
+@dynamic dismissBlock;
+
+- (void)setDismissBlock:(DismissBlock)dismissBlock
+{
+    objc_setAssociatedObject(self, &DISMISS_IDENTIFER, dismissBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (DismissBlock)dismissBlock
+{
+    return objc_getAssociatedObject(self, &DISMISS_IDENTIFER);
+}
+
+- (void)setCancelBlock:(CancelBlock)cancelBlock
+{
+    objc_setAssociatedObject(self, &CANCEL_IDENTIFER, cancelBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (CancelBlock)cancelBlock
+{
+    return objc_getAssociatedObject(self, &CANCEL_IDENTIFER);
+}
+
 
 + (UIAlertView*) alertViewWithTitle:(NSString*) title                    
                     message:(NSString*) message 
@@ -19,18 +44,15 @@ static CancelBlock _cancelBlock;
           otherButtonTitles:(NSArray*) otherButtons
                   onDismiss:(DismissBlock) dismissed                   
                    onCancel:(CancelBlock) cancelled {
-    
-    [_cancelBlock release];
-    _cancelBlock  = [cancelled copy];
-
-    [_dismissBlock release];
-    _dismissBlock  = [dismissed copy];
-    
+        
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title
                                                     message:message
                                                    delegate:[self class]
                                           cancelButtonTitle:cancelButtonTitle
                                           otherButtonTitles:nil];
+    
+    [alert setDismissBlock:dismissed];
+    [alert setCancelBlock:cancelled];
     
     for(NSString *buttonTitle in otherButtons)
         [alert addButtonWithTitle:buttonTitle];
@@ -64,11 +86,15 @@ static CancelBlock _cancelBlock;
     
 	if(buttonIndex == [alertView cancelButtonIndex])
 	{
-		_cancelBlock();
+		if (alertView.cancelBlock) {
+            alertView.cancelBlock();
+        }
 	}
     else
     {
-        _dismissBlock(buttonIndex - 1); // cancel button is button 0
+        if (alertView.dismissBlock) {
+            alertView.dismissBlock(buttonIndex - 1); // cancel button is button 0
+        }
     }
 }
 


### PR DESCRIPTION
Static blocks works as long as there are no multiple UIAlertViews appearing. However, if two or more UIAlertViews appear, only the blocks of the latter will be used. This solves that problem by using objc runtime to set properties on categories.
